### PR TITLE
Fixed hard-coded archive type (store was always using DPSArchive)

### DIFF
--- a/src/main/java/org/webcurator/core/store/arc/ArcDigitalAssetStoreService.java
+++ b/src/main/java/org/webcurator/core/store/arc/ArcDigitalAssetStoreService.java
@@ -62,13 +62,13 @@ import org.archive.io.warc.WARCWriterPoolSettings;
 import org.archive.io.warc.WARCWriterPoolSettingsData;
 import org.archive.uid.UUIDGenerator;
 import org.archive.util.anvl.ANVLRecord;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.ApplicationContext;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.webcurator.core.archive.Archive;
 import org.webcurator.core.archive.ArchiveFile;
-import org.webcurator.core.archive.dps.DPSArchive;
 import org.webcurator.core.archive.file.FileArchive;
 import org.webcurator.core.harvester.coordinator.HarvestCoordinatorPaths;
 import org.webcurator.core.rest.RestClientResponseHandler;
@@ -86,7 +86,6 @@ import org.webcurator.domain.model.core.HarvestResultDTO;
 import org.webcurator.domain.model.core.CustomDepositFormCriteriaDTO;
 import org.webcurator.domain.model.core.CustomDepositFormResultDTO;
 import org.webcurator.domain.model.core.HarvestResourceDTO;
-import org.webcurator.domain.model.core.HarvestResultDTO;
 import org.webcurator.domain.model.core.LogFilePropertiesDTO;
 
 /**
@@ -131,6 +130,9 @@ public class ArcDigitalAssetStoreService implements DigitalAssetStore, LogProvid
 
     private FileArchive fileArchive = null;
 
+    @Autowired
+    private Archive arcDasArchive;
+
     private String pageImagePrefix = "PageImage";
     private String aqaReportPrefix = "aqa-report";
 
@@ -147,7 +149,8 @@ public class ArcDigitalAssetStoreService implements DigitalAssetStore, LogProvid
     }
 
     public String baseUrl() {
-        return wsEndPoint.getHost() + ":" + wsEndPoint.getPort();
+        // FIXME: configurable scheme (in class WebServiceEndpoint.java)
+        return "http://" + wsEndPoint.getHost() + ":" + wsEndPoint.getPort();
     }
 
     public String getUrl(String appendUrl) {
@@ -1270,9 +1273,7 @@ public class ArcDigitalAssetStoreService implements DigitalAssetStore, LogProvid
                     fileList.add(new ArchiveFile(f, ARC_FILE));
                 }
 
-                ApplicationContext ctx = ApplicationContextFactory.getApplicationContext();
-                Archive archive = ctx.getBean(DPSArchive.class);
-                String archiveIID = archive.submitToArchive(targetInstanceOid,
+                String archiveIID = arcDasArchive.submitToArchive(targetInstanceOid,
                         SIP, xAttributes, fileList);
 
                 completeArchiving(Long.parseLong(targetInstanceOid), archiveIID);
@@ -1313,9 +1314,7 @@ public class ArcDigitalAssetStoreService implements DigitalAssetStore, LogProvid
     public CustomDepositFormResultDTO getCustomDepositFormDetails(
             CustomDepositFormCriteriaDTO criteria)
             throws DigitalAssetStoreException {
-        ApplicationContext ctx = ApplicationContextFactory.getApplicationContext();
-        Archive archive = ctx.getBean(DPSArchive.class);
-        return archive.getCustomDepositFormDetails(criteria);
+        return arcDasArchive.getCustomDepositFormDetails(criteria);
     }
 
 

--- a/src/main/java/org/webcurator/store/webapp/beans/config/DasConfig.java
+++ b/src/main/java/org/webcurator/store/webapp/beans/config/DasConfig.java
@@ -286,7 +286,7 @@ public class DasConfig {
         bean.setDasFileMover(createDasFileMover());
         bean.setPageImagePrefix(arcDigitalAssetStoreServicePageImagePrefix);
         bean.setAqaReportPrefix(arcDigitalAssetStoreServiceAqaReportPrefix);
-        bean.setFileArchive(fileArchive());
+        bean.setFileArchive(createFileArchive());
 
         return bean;
     }
@@ -304,29 +304,32 @@ public class DasConfig {
         return dasFileMover;
     }
 
+    @Bean
+    @Scope(BeanDefinition.SCOPE_SINGLETON)
+    @Lazy(false) // lazy-init="default", but no default has been set for wct-das.xml
     // The archive type is one of: fileArchive, omsArchive, dpsArchive.
-    public Archive createArcDigitalAssetStoreServiceArchive() {
-        Archive archive = null;
+    public Archive arcDasArchive() {
+        Archive bean = null;
         String archiveType = arcDigitalAssetStoreServiceArchive;
         if ("fileArchive".equalsIgnoreCase(archiveType)) {
-            archive = new FileArchive();
+            bean = createFileArchive();
         } else if ("omsArchive".equalsIgnoreCase(archiveType)) {
-            archive = new OMSArchive();
+            bean = createOmsArchive();
         } else if ("dpsArchive".equalsIgnoreCase(archiveType)) {
-            archive = new DPSArchive();
+            bean = createDpsArchive();
         } else  {
             LOGGER.debug("Instantiating Archive class for name=" + archiveType);
             if (archiveType.trim().length() > 0) {
                 try {
                     Class<?> clazz = Class.forName(archiveType);
                     Object archiveInstance = clazz.newInstance();
-                    archive = (Archive) archiveInstance;
+                    bean = (Archive) archiveInstance;
                 } catch (InstantiationException|IllegalAccessException|ClassNotFoundException e) {
                     LOGGER.error("Unable to instantiate archive by type/class=" + archiveType, e);
                 }
             }
         }
-        return archive;
+        return bean;
     }
 
     @Bean
@@ -430,23 +433,18 @@ public class DasConfig {
         return bean;
     }
 
-    @Bean
-    @Scope(BeanDefinition.SCOPE_SINGLETON)
-    @Lazy(false) // lazy-init="default", but no default has been set for wct-das.xml
-    public FileArchive fileArchive() {
+    private FileArchive createFileArchive() {
         FileArchive bean = new FileArchive();
         bean.setArchiveRepository(fileArchiveArchiveRepository);
         bean.setArchiveLogReportFiles(fileArchiveArchiveLogReportFiles);
         bean.setArchiveLogDirectory(fileArchiveArchiveLogDirectory);
         bean.setArchiveArcDirectory(fileArchiveArchiveArcDirectory);
+        bean.setArchiveReportDirectory(fileArchiveArchiveReportDirectory);
 
         return bean;
     }
 
-    @Bean
-    @Scope(BeanDefinition.SCOPE_SINGLETON)
-    @Lazy(false) // lazy-init="default", but no default has been set for wct-das.xml
-    public OMSArchive omsArchive() {
+    private OMSArchive createOmsArchive() {
         OMSArchive bean = new OMSArchive();
         bean.setArchiveLogReportFiles(omsArchiveArchiveLogReportFiles);
         bean.setUrl(omsArchiveUrl);
@@ -467,10 +465,7 @@ public class DasConfig {
 
     // Configuration parameters for the Submit-To-Rosetta module which submits a harvest into Ex Libris Rosetta System
     // (a.k.a. DPS, the Digital Preservation System).
-    @Bean
-    @Scope(BeanDefinition.SCOPE_SINGLETON)
-    @Lazy(false) // lazy-init="default", but no default has been set for wct-das.xml
-    public DPSArchive dpsArchive() {
+    private DPSArchive createDpsArchive() {
         DPSArchive bean = new DPSArchive();
         bean.setPdsUrl(dpsArchivePdsUrl);
         bean.setFtpHost(dpsArchiveFtpHost);


### PR DESCRIPTION
At some point during the tech uplift the DPSArchive was hard-coded as the archive back end for the store. Apparently, this was a fix for a null pointer issue. This PR makes the archive type configurable again.

There was also an issue with the http requests from store to webapp: the URL was missing the scheme part.